### PR TITLE
FIX: Only refresh travis list when it's actually different.

### DIFF
--- a/jobs/travis.rb
+++ b/jobs/travis.rb
@@ -5,6 +5,8 @@ require 'net/https'
 require 'cgi'
 require File.expand_path('../../lib/travis_backend', __FILE__)
 
+$lastTravisItems = []
+
 SCHEDULER.every '2m', :first_in => '1s' do |job|
 	backend = TravisBackend.new
 	repo_slugs = []
@@ -85,9 +87,14 @@ SCHEDULER.every '2m', :first_in => '1s' do |job|
 			[3,item['label']]
 		end
 	end
-	
-	send_event('travis', {
-		unordered: true,
-		items: items
-	})
+
+	if items != $lastTravisItems
+		send_event('travis', {
+			unordered: true,
+			items: items
+		})
+	end
+
+	$lastTravisItems = items
+
 end


### PR DESCRIPTION
Refreshing travis every 2 minutes does a great job of keeping the dashboard up-to-date, but right now
it creates a lot of unnecessary flickering.

This patch blocks the send_event() command unless the items are actually different.  It uses a global
variable (gack) but it wasn't clear to me where a non-global variable would be placed.
