### PR TITLE
Fixes error when a repos has zero commits.

### DIFF
--- a/lib/github_backend.rb
+++ b/lib/github_backend.rb
@@ -24,6 +24,7 @@ class GithubBackend
 			# Can't limit timeframe
 			begin
 				stats = request('contributors_stats', [repo]) || []
+				next unless stats.is_a?(Array)
 				stats.each do |stat|
 					stat.weeks.each do |week|
 						next unless stat.author


### PR DESCRIPTION
```
scheduler caught exception:
undefined method `each' for "":String
lib/github_backend.rb:31:in `block in contributor_stats_by_author'
lib/github_backend.rb:23:in `each'
...
```
