### PR TITLE
Updated version of json gem, since 1.7 was not installable on Macs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rake'
 gem 'dashing'
-gem 'json', '~> 1.7.7'
+gem 'json', '~> 1.8.2'
 gem 'dotenv'
 gem 'octokit'
 gem 'i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
     ffi (1.9.10)
     hike (1.2.3)
     i18n (0.7.0)
-    json (1.7.7)
+    json (1.8.3)
     minitest (5.8.4)
     multi_json (1.11.2)
     multipart-post (2.0.0)
@@ -114,10 +114,13 @@ DEPENDENCIES
   faraday (~> 0.9)
   faraday-http-cache
   i18n
-  json (~> 1.7.7)
+  json (~> 1.8.2)
   octokit
   rake
   rspec
   rspec-mocks
   sentry-raven!
   typhoeus
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
I was running into a problem with installing JSON gem v1.7 on Macs using ruby v2.2. I've updated version and application started just fine, I didn't notice any problems with the application itself.
