### PR TITLE
Added way to authenticate to private Travis repositories

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,4 +7,4 @@ GITHUB_OAUTH_TOKEN=
 LEADERBOARD_WEIGHTING=issues_opened=5,issues_closed=5,pulls_opened=10,pulls_closed=5,pulls_comments=1,issues_comments=1,commits_comments=1,commits=20
 TRAVIS_BRANCH_BLACKLIST={"silverstripe-labs/silverstripe-newsletter":["0.3","0.4"]}
 SENTRY_DSN=
-
+#TRAVIS_API_TOKEN=#Add Travis authorization token, for private repo.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ All configuration is optional, apart from either `ORGAS` or `REPOS`.
    This is useful to ignore old branches which no longer have active builds.
    Example: `{"silverstripe-labs/silverstripe-newsletter":["0.3","0.4"]}`
  * `TRAVIS_API_ENDPOINT`: Defaults to `https://api.travis-ci.org/`. Switch to `https://api.travis-ci.com/` for private builds.
+ * `TRAVIS_API_TOKEN`: Use if you have private repositories. Don't confuse with GIT token.
 
 You can also specify a custom env file through setting a `DOTENV_FILE` environment variable first.
 This is useful if you want to have version controlled defaults (see `.env.silverstripe`).


### PR DESCRIPTION
Added way to authenticate to private Travis repositories using TRAVIS_API_TOKEN environment variable.

This dashboard already supports working with Pro version of Travis, but for some reason, I failed to configure it working with my token as part of URL(e.g. https://<my-token>@api.travis.com, as you would do when simply using CURL in CLI).

So I've implemented this change, works fine for me, wasn't testing it much on other repositories, though.
